### PR TITLE
#2 Docker環境でのMySQLの設定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3.9"
+
+services:
+  db:
+    image: mysql:8.0
+    container_name: attendance-db
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: attendance_db
+      MYSQL_USER: appuser
+      MYSQL_PASSWORD: apppass
+      TZ: Asia/Tokyo
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+
+volumes:
+  db_data:


### PR DESCRIPTION
## 概要
MySQL を Docker で起動できるようにする設定を追加しました．

## 変更内容
- docker-compose.yml を追加
- MySQL 8.0 コンテナ構築
- ボリュームによるデータ永続化を設定

## 関連Issue
Closes #2
