### PR TITLE
#5 出勤・退勤APIの実装

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/ryoito218/attendance-gin-app/internal/db"
+	"github.com/ryoito218/attendance-gin-app/internal/handler"
 )
 
 func main() {
@@ -23,9 +24,14 @@ func main() {
 
 	r := gin.Default()
 
+	attendanceHandler := handler.NewAttendanceHandler(d)
+
 	r.GET("/health", func(c *gin.Context) {
 		c.String(http.StatusOK, "ok")
 	})
+
+	r.POST("/api/clock-in", attendanceHandler.ClockIn)
+	r.POST("/api/clock-out", attendanceHandler.ClockOut)
 
 	if err := r.Run(":8080"); err != nil {
 		log.Fatal(err)

--- a/internal/handler/attendance_handler.go
+++ b/internal/handler/attendance_handler.go
@@ -1,0 +1,123 @@
+package handler
+
+import (
+	"database/sql"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const fixedUserID = 1
+
+type AttendanceHandler struct {
+	DB *sql.DB
+}
+
+func NewAttendanceHandler(db *sql.DB) *AttendanceHandler {
+	return &AttendanceHandler{DB: db}
+}
+
+func (h *AttendanceHandler) ClockIn(c *gin.Context) {
+	now := time.Now()
+	workDate := now.Format("2006-01-02")
+
+	var id int
+	var clockIn, clockOut sql.NullTime
+
+	err := h.DB.QueryRow(
+		`SELECT id, clock_in, clock_out
+		 FROM attendance
+		 WHERE user_id = ? AND work_date = ?`,
+		fixedUserID, workDate,
+	).Scan(&id, &clockIn, &clockOut)
+
+	switch {
+	case err == sql.ErrNoRows:
+		_, err := h.DB.Exec(
+			`INSERT INTO attendance (user_id, work_date, clock_in)
+			 VALUES (?, ?, ?)`,
+			fixedUserID, workDate, now,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to insert clock_in"})
+			return 
+		}
+	case err != nil:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+		return
+	default:
+		if clockIn.Valid {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "already clocked in"})
+			return 
+		}
+
+		// なぜ存在
+		_, err := h.DB.Exec(
+			`UPDATE attendance
+			 SET clock_in = ?
+			 WHERE id = ?`,
+			now, id,
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update clock_in"})
+			return
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status": "ok",
+		"work_date": workDate,
+		"clock_in": now,
+	})
+}
+
+func (h *AttendanceHandler) ClockOut(c *gin.Context) {
+	now := time.Now()
+	workDate := now.Format("2006-01-02")
+
+	var id int
+	var clockIn, clockOut sql.NullTime
+
+	err := h.DB.QueryRow(
+		`SELECT id, clock_in, clock_out
+		 FROM attendance
+		 WHERE user_id = ? AND work_date = ?`,
+		fixedUserID, workDate,
+	).Scan(&id, &clockIn, &clockOut)
+
+	if err == sql.ErrNoRows {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no attendance record for today"})
+		return
+	}
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+		return
+	}
+
+	if !clockIn.Valid {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "not clocked in yet"})
+	}
+
+	if clockOut.Valid {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "already clocked out"})
+	}
+
+	_, err = h.DB.Exec(
+		`UPDATE attendance
+		 SET clock_out = ?
+		 WHERE id = ?`,
+		now, id,
+	)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update clock_out"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status": "ok",
+		"work_date": workDate,
+		"clock_out": now,
+	})
+}


### PR DESCRIPTION
## 概要
Issue #5 に対応し，出勤・退勤APIを実装しました．

## 変更内容
- internal/handler/attendance_handler.go を追加
  - POST /api/clock-in
  - POST /api/clock-out
  - 当日の attendance レコードを作成／更新
  - 二重出勤／二重退勤時には 400 エラーを返却
- cmd/app/main.go を更新
  - Gin のルーティングに /api/clock-in と /api/clock-out を追加

## 動作確認
- docker compose up -d で MySQL を起動
- go run ./cmd/app でアプリを起動
- curl で以下を確認
  - POST /api/clock-in が 200 で成功すること
  - 同じ日付で再度 POST /api/clock-in すると 400 エラーになること
  - POST /api/clock-out が 200 で成功すること
  - 二重退勤時に 400 エラーになること

## 関連Issue
Closes #5
