### PR TITLE
#6 勤退一覧APIの実装

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -32,6 +32,7 @@ func main() {
 
 	r.POST("/api/clock-in", attendanceHandler.ClockIn)
 	r.POST("/api/clock-out", attendanceHandler.ClockOut)
+	r.GET("/api/attendance", attendanceHandler.ListAttendance)
 
 	if err := r.Run(":8080"); err != nil {
 		log.Fatal(err)

--- a/internal/handler/attendance_handler.go
+++ b/internal/handler/attendance_handler.go
@@ -3,9 +3,11 @@ package handler
 import (
 	"database/sql"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/ryoito218/attendance-gin-app/internal/domain"
 )
 
 const fixedUserID = 1
@@ -41,7 +43,7 @@ func (h *AttendanceHandler) ClockIn(c *gin.Context) {
 		)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to insert clock_in"})
-			return 
+			return
 		}
 	case err != nil:
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
@@ -49,7 +51,7 @@ func (h *AttendanceHandler) ClockIn(c *gin.Context) {
 	default:
 		if clockIn.Valid {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "already clocked in"})
-			return 
+			return
 		}
 
 		// なぜ存在
@@ -66,9 +68,9 @@ func (h *AttendanceHandler) ClockIn(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": "ok",
+		"status":    "ok",
 		"work_date": workDate,
-		"clock_in": now,
+		"clock_in":  now,
 	})
 }
 
@@ -98,10 +100,12 @@ func (h *AttendanceHandler) ClockOut(c *gin.Context) {
 
 	if !clockIn.Valid {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "not clocked in yet"})
+		return
 	}
 
 	if clockOut.Valid {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "already clocked out"})
+		return
 	}
 
 	_, err = h.DB.Exec(
@@ -116,8 +120,95 @@ func (h *AttendanceHandler) ClockOut(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"status": "ok",
+		"status":    "ok",
 		"work_date": workDate,
 		"clock_out": now,
 	})
+}
+
+type AttendanceRecordResponse struct {
+	WorkDate            string  `json:"work_date"`
+	ClockIn             *string `json:"clock_in,omitempty"`  // なぜポインタ型？
+	ClockOut            *string `json:"clock_out,omitempty"` // なぜポインタ型？
+	WorkDurationMinutes int     `json:"work_duration_minutes"`
+}
+
+func (h *AttendanceHandler) ListAttendance(c *gin.Context) {
+	daysStr := c.DefaultQuery("days", "7")
+
+	days, err := strconv.Atoi(daysStr)
+	if err != nil || days <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid days"})
+		return
+	}
+
+	now := time.Now()
+	startDate := now.AddDate(0, 0, -(days - 1)).Format("2006-01-02")
+	endDate := now.Format("2006-01-02")
+
+	rows, err := h.DB.Query(
+		`SELECT work_date, clock_in, clock_out
+		 FROM attendance
+		 WHERE user_id = ?
+		   AND work_date BETWEEN ? AND ?
+		 ORDER BY work_date DESC
+		`,
+		fixedUserID, startDate, endDate,
+	)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+		return
+	}
+	defer rows.Close()
+
+	var result []AttendanceRecordResponse
+
+	for rows.Next() {
+		var workDate time.Time
+		var clockIn, clockOut sql.NullTime
+
+		if err := rows.Scan(&workDate, &clockIn, &clockOut); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan"})
+			return
+		}
+
+		var clockInStr *string
+		var clockOutStr *string
+		var durationMinutes int
+
+		if clockIn.Valid && clockOut.Valid {
+			d := domain.CalcWorkDuration(clockIn.Time, clockOut.Time)
+			durationMinutes = int(d.Minutes())
+
+			s := clockIn.Time.Format(time.RFC3339)
+			clockInStr = &s
+			e := clockOut.Time.Format(time.RFC3339)
+			clockOutStr = &e
+		} else {
+			if clockIn.Valid {
+				s := clockIn.Time.Format(time.RFC3339)
+				clockInStr = &s
+			}
+			if clockOut.Valid {
+				e := clockOut.Time.Format(time.RFC3339)
+				clockOutStr = &e
+			}
+			durationMinutes = 0
+
+		}
+
+		result = append(result, AttendanceRecordResponse{
+			WorkDate:            workDate.Format("2006-01-02"),
+			ClockIn:             clockInStr,
+			ClockOut:            clockOutStr,
+			WorkDurationMinutes: durationMinutes,
+		})
+	}
+
+	if err := rows.Err(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "rows error"})
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
 }


### PR DESCRIPTION
## 概要
Issue #6 に対応し，勤退一覧APIを実装しました．

## 変更内容
- internal/handler/attendance_handler.go
  - AttendanceRecordResponse 構造体を追加
  - ListAttendance ハンドラを追加（GET /api/attendance）
  - days クエリで取得日数を指定可能（デフォルト7日）
  - CalcWorkDuration を用いて勤務時間を分単位で計算
- cmd/app/main.go
  - /api/attendance のルーティングを追加

## 動作確認
- docker compose up -d で MySQL を起動
- go run ./cmd/app でアプリを起動
- curl で以下を確認
  - POST /api/clock-in /clock-out で打刻できる
  - GET /api/attendance で勤怠一覧が取得できる
  - days クエリに不正値を渡すと 400 となる

## 関連Issue
Closes #6