### PR TITLE
#8 シンプルなフロントエンド画面の作成

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -26,6 +26,12 @@ func main() {
 
 	attendanceHandler := handler.NewAttendanceHandler(d)
 
+	r.GET("/", func(c *gin.Context) {
+		c.File("./public/index.html")
+	})
+
+	r.Static("/static", "./public")
+
 	r.GET("/health", func(c *gin.Context) {
 		c.String(http.StatusOK, "ok")
 	})

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,214 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>勤怠管理アプリ（MVP）</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      max-width: 800px;
+      margin: 20px auto;
+      padding: 0 16px;
+    }
+    h1 {
+      font-size: 1.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .controls {
+      margin-bottom: 16px;
+    }
+    button {
+      padding: 8px 16px;
+      margin-right: 8px;
+      cursor: pointer;
+    }
+    #message {
+      margin-top: 8px;
+      min-height: 1.2em;
+      font-size: 0.9rem;
+    }
+    #message.ok {
+      color: green;
+    }
+    #message.error {
+      color: red;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin-top: 16px;
+    }
+    th, td {
+      border: 1px solid #ccc;
+      padding: 4px 8px;
+      text-align: left;
+      font-size: 0.9rem;
+    }
+    th {
+      background-color: #f5f5f5;
+    }
+    .small {
+      font-size: 0.8rem;
+      color: #555;
+    }
+  </style>
+</head>
+<body>
+  <h1>勤怠管理アプリ（MVP）</h1>
+
+  <div class="controls">
+    <button id="clockInBtn">出勤</button>
+    <button id="clockOutBtn">退勤</button>
+    <button id="refreshBtn">一覧更新</button>
+    <span class="small">（デフォルトで直近7日分を表示）</span>
+    <div id="message"></div>
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th>日付</th>
+        <th>出勤</th>
+        <th>退勤</th>
+        <th>勤務時間（分）</th>
+      </tr>
+    </thead>
+    <tbody id="attendanceBody">
+      <!-- JSで埋める -->
+    </tbody>
+  </table>
+
+  <script>
+    const messageEl = document.getElementById("message");
+    const tbody = document.getElementById("attendanceBody");
+
+    function showMessage(text, isError = false) {
+      messageEl.textContent = text;
+      messageEl.className = "";
+      if (text === "") {
+        return;
+      }
+      if (isError) {
+        messageEl.classList.add("error");
+      } else {
+        messageEl.classList.add("ok");
+      }
+    }
+
+    async function postClockIn() {
+      showMessage("出勤処理中です…");
+      try {
+        const res = await fetch("/api/clock-in", {
+          method: "POST"
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          showMessage(`出勤エラー: ${data.error || "unknown error"}`, true);
+          return;
+        }
+        showMessage("出勤しました．");
+        await fetchAttendance();
+      } catch (e) {
+        console.error(e);
+        showMessage("出勤処理中にエラーが発生しました．", true);
+      }
+    }
+
+    async function postClockOut() {
+      showMessage("退勤処理中です…");
+      try {
+        const res = await fetch("/api/clock-out", {
+          method: "POST"
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          showMessage(`退勤エラー: ${data.error || "unknown error"}`, true);
+          return;
+        }
+        showMessage("退勤しました．");
+        await fetchAttendance();
+      } catch (e) {
+        console.error(e);
+        showMessage("退勤処理中にエラーが発生しました．", true);
+      }
+    }
+
+    function formatDateTime(str) {
+      if (!str) {
+        return "";
+      }
+      // 例: 2025-01-01T09:00:00+09:00 → 2025-01-01 09:00
+      const d = new Date(str);
+      if (isNaN(d.getTime())) {
+        return str;
+      }
+      const y = d.getFullYear();
+      const m = String(d.getMonth() + 1).padStart(2, "0");
+      const day = String(d.getDate()).padStart(2, "0");
+      const hh = String(d.getHours()).padStart(2, "0");
+      const mm = String(d.getMinutes()).padStart(2, "0");
+      return `${y}-${m}-${day} ${hh}:${mm}`;
+    }
+
+    async function fetchAttendance() {
+      showMessage("一覧取得中です…");
+      try {
+        const res = await fetch("/api/attendance");
+        if (!res.ok) {
+          showMessage("一覧取得に失敗しました．", true);
+          return;
+        }
+        const list = await res.json();
+        tbody.innerHTML = "";
+
+        if (!Array.isArray(list) || list.length === 0) {
+          const tr = document.createElement("tr");
+          const td = document.createElement("td");
+          td.colSpan = 4;
+          td.textContent = "データがありません．";
+          tr.appendChild(td);
+          tbody.appendChild(tr);
+          showMessage("一覧を更新しました．");
+          return;
+        }
+
+        list.forEach(item => {
+          const tr = document.createElement("tr");
+
+          const tdDate = document.createElement("td");
+          tdDate.textContent = item.work_date || "";
+          tr.appendChild(tdDate);
+
+          const tdIn = document.createElement("td");
+          tdIn.textContent = item.clock_in ? formatDateTime(item.clock_in) : "";
+          tr.appendChild(tdIn);
+
+          const tdOut = document.createElement("td");
+          tdOut.textContent = item.clock_out ? formatDateTime(item.clock_out) : "";
+          tr.appendChild(tdOut);
+
+          const tdDur = document.createElement("td");
+          tdDur.textContent = item.work_duration_minutes != null
+            ? String(item.work_duration_minutes)
+            : "";
+          tr.appendChild(tdDur);
+
+          tbody.appendChild(tr);
+        });
+
+        showMessage("一覧を更新しました．");
+      } catch (e) {
+        console.error(e);
+        showMessage("一覧取得中にエラーが発生しました．", true);
+      }
+    }
+
+    document.getElementById("clockInBtn").addEventListener("click", postClockIn);
+    document.getElementById("clockOutBtn").addEventListener("click", postClockOut);
+    document.getElementById("refreshBtn").addEventListener("click", fetchAttendance);
+
+    // 初期表示時に一覧を取得
+    fetchAttendance();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 概要
Issue #8 に対応し，勤怠APIを操作するためのシンプルなフロントエンド画面を追加しました．

## 変更内容
- cmd/app/main.go
  - public ディレクトリを静的ファイルとして配信するように設定
- public/index.html
  - 出勤・退勤ボタンを配置
  - 一覧更新ボタンで GET /api/attendance を呼び出し，テーブル表示
  - エラーメッセージや成功メッセージを画面に表示

## 動作確認
- docker compose up -d で MySQL を起動
- go run ./cmd/app でアプリを起動
- ブラウザで http://localhost:8080/ にアクセスし，以下を確認
  - 出勤ボタンで POST /api/clock-in が成功する
  - 退勤ボタンで POST /api/clock-out が成功する
  - 一覧更新ボタンで GET /api/attendance の結果がテーブルに表示される

## 関連Issue
Closes #8
