### PR TITLE
#10 GitHub Actions による CI（go test）の設定

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: rootpass
+          MYSQL_DATABASE: attendance_db
+          MYSQL_USER: appuser
+          MYSQL_PASSWORD: apppass
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uappuser -papppass --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      DB_HOST: 127.0.0.1
+      DB_USER: appuser
+      DB_PASSWORD: apppass
+      DB_NAME: attendance_db
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Wait for MySQL
+        run: |
+          for i in {1..30}; do
+            if mysqladmin ping -h 127.0.0.1 -uappuser -papppass --silent; then
+              echo "MySQL is up"
+              break
+            fi
+            echo "Waiting for MySQL..."
+            sleep 2
+          done
+
+      - name: Create attendance table
+        run: |
+          mysql -h 127.0.0.1 -uappuser -papppass attendance_db <<'SQL'
+          CREATE TABLE IF NOT EXISTS attendance (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            user_id INT NOT NULL,
+            work_date DATE NOT NULL,
+            clock_in DATETIME NULL,
+            clock_out DATETIME NULL,
+            UNIQUE KEY uniq_user_date (user_id, work_date)
+          );
+          SQL
+
+      - name: Run tests
+        run: go test ./...


### PR DESCRIPTION
## 概要
Issue #10 に対応し，GitHub Actions による go test の CI を追加しました．

## 変更内容
- .github/workflows/ci.yml を追加
  - Ubuntu 上で Go をセットアップ
  - MySQL 8.0 のサービスコンテナを起動
  - attendance テーブルを作成
  - go test ./... を実行

## 動作確認
- この PR の Checks タブで CI が実行され，go test ./... が成功することを確認

## 関連Issue
Closes #10